### PR TITLE
Add basic Programs API client

### DIFF
--- a/api-docs/endpoints.md
+++ b/api-docs/endpoints.md
@@ -1,0 +1,12 @@
+# Programs API endpoints
+
+- **GET /v3/schema/v1/programs/expiring** — ### List published objects that will expire within 30 days, ascending order
+- **GET /v3/schema/v1/programs/future** — ### List objects that are available in the future, ascending order
+- **GET /v3/schema/v1/programs/last_modified** — ### List objects by last modification time, descending order
+- **GET /v3/schema/v1/programs/latest** — ### List published objects by publication time, descending order
+- **GET /v3/schema/v1/programs/popular** — ### List published objects by popularity, descending order
+- **GET /v3/schema/v3/programs/expiring** — ### List published objects that will expire within 30 days, ascending order
+- **GET /v3/schema/v3/programs/future** — ### List objects that are available in the future, ascending order
+- **GET /v3/schema/v3/programs/last_modified** — ### List objects by last modification time, descending order
+- **GET /v3/schema/v3/programs/latest** — ### List published objects by publication time, descending order
+- **GET /v3/schema/v3/programs/popular** — ### List published objects by popularity, descending order

--- a/src/areena_api.py
+++ b/src/areena_api.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import httpx
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class Item(BaseModel):
+    id: str
+    type: str
+    mediaType: str
+    version: int = Field(alias="_version")
+    title: Optional[Dict[str, str]] = None
+    description: Optional[Dict[str, str]] = None
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
+class ProgramSearch(BaseModel):
+    data: List[Item]
+    meta: Dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ProgramAPI:
+    """Minimal wrapper for Yle Programs API V3."""
+
+    BASE_URL = "https://programs.api.yle.fi"
+
+    def __init__(self, app_id: str, app_key: str, *, client: Optional[httpx.Client] = None) -> None:
+        self.app_id = app_id
+        self.app_key = app_key
+        self._client = client or httpx.Client(base_url=self.BASE_URL)
+        self._own_client = client is None
+
+    def close(self) -> None:
+        if self._own_client:
+            self._client.close()
+
+    def _params(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        auth = {"app_id": self.app_id, "app_key": self.app_key}
+        auth.update(params)
+        return auth
+
+    def search(self, q: str, **params: Any) -> ProgramSearch:
+        """Search items."""
+        resp = self._client.get("/v3/schema/v3/items", params=self._params({"q": q, **params}))
+        resp.raise_for_status()
+        return ProgramSearch.model_validate(resp.json())
+
+    def get_item(self, item_id: str, **params: Any) -> Item:
+        """Fetch a single item by id."""
+        resp = self._client.get(f"/v3/schema/v3/items/{item_id}", params=self._params(params))
+        resp.raise_for_status()
+        payload = resp.json()
+        if "data" in payload:
+            payload = payload["data"]
+        return Item.model_validate(payload)
+
+    def __enter__(self) -> "ProgramAPI":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()


### PR DESCRIPTION
## Summary
- add basic Item and ProgramSearch models
- implement ProgramAPI with search and get_item methods
- provide a short list of Programs API endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'resources')*

------
https://chatgpt.com/codex/tasks/task_e_685d45ae751c83319a31c65a3a1aaeea