### PR TITLE
Add endpoint doc and unify API credentials

### DIFF
--- a/api-docs/endpoints.md
+++ b/api-docs/endpoints.md
@@ -1,0 +1,10 @@
+- **GET /v3/schema/v1/programs/expiring** — List published objects that will expire within 30 days, ascending order
+- **GET /v3/schema/v1/programs/future** — List objects that are available in the future, ascending order
+- **GET /v3/schema/v1/programs/last_modified** — List objects by last modification time, descending order
+- **GET /v3/schema/v1/programs/latest** — List published objects by publication time, descending order
+- **GET /v3/schema/v1/programs/popular** — List published objects by popularity, descending order
+- **GET /v3/schema/v3/programs/expiring** — List published objects that will expire within 30 days, ascending order
+- **GET /v3/schema/v3/programs/future** — List objects that are available in the future, ascending order
+- **GET /v3/schema/v3/programs/last_modified** — List objects by last modification time, descending order
+- **GET /v3/schema/v3/programs/latest** — List published objects by publication time, descending order
+- **GET /v3/schema/v3/programs/popular** — List published objects by popularity, descending order

--- a/resources/__init__.py
+++ b/resources/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+# Default API credentials for Yle Areena
+APP_ID = os.environ.setdefault('YLE_APP_ID', 'player_static_prod')
+APP_KEY = os.environ.setdefault('YLE_APP_KEY', '8930d72170e48303cf5f3867780d549b')
+

--- a/resources/lib/__init__.py
+++ b/resources/lib/__init__.py
@@ -1,0 +1,4 @@
+from .. import APP_ID, APP_KEY
+
+__all__ = ['APP_ID', 'APP_KEY']
+

--- a/resources/lib/areena.py
+++ b/resources/lib/areena.py
@@ -1,4 +1,5 @@
 import requests  # type: ignore
+from .. import APP_ID, APP_KEY
 from . import logger
 from .playlist import download_playlist, parse_playlist_seasons
 from .extractor import duration_from_search_result, parse_finnish_date
@@ -199,8 +200,8 @@ def _parse_search_results(search_response: Dict, pagination_links: bool = True) 
 
 def _search_url(keyword: str, offset: int, page_size: int) -> str:
     q = urlencode({
-        'app_id': 'areena-web-items',
-        'app_key': 'wlTs5D9OjIdeS9krPzRQR4I1PYVzoazN',
+        'app_id': APP_ID,
+        'app_key': APP_KEY,
         'client': 'yle-areena-web',
         'language': 'fi',
         'v': 10,
@@ -263,8 +264,8 @@ def _sport_live_url(offset: int, page_size: int) -> str:
         'limit': str(page_size),
         'country': 'FI',
         'isPortabilityRegion': 'true',
-        'app_id': 'areena-web-items',
-        'app_key': 'wlTs5D9OjIdeS9krPzRQR4I1PYVzoazN'
+        'app_id': APP_ID,
+        'app_key': APP_KEY
     })
     return f'https://areena.api.yle.fi/v1/ui/content/list?{q}'
 
@@ -281,7 +282,7 @@ def _only_in_areena_live_url(offset: int, page_size: int) -> str:
         'limit': str(page_size),
         'country': 'FI',
         'isPortabilityRegion': 'true',
-        'app_id': 'areena-web-items',
-        'app_key': 'wlTs5D9OjIdeS9krPzRQR4I1PYVzoazN'
+        'app_id': APP_ID,
+        'app_key': APP_KEY
     })
     return f'https://areena.api.yle.fi/v1/ui/content/list?{q}'

--- a/resources/lib/extractor.py
+++ b/resources/lib/extractor.py
@@ -1,5 +1,6 @@
 import re
 import requests  # type: ignore
+from .. import APP_ID, APP_KEY
 from . import logger
 from .manifesturl import ManifestUrl, random_elisa_ipv4
 from datetime import datetime
@@ -133,11 +134,12 @@ def preview_parser(pid: str) -> AreenaPreviewApiResponse:
 
 
 def preview_url(pid: str) -> str:
-    return f'https://player.api.yle.fi/v1/preview/{pid}.json?' \
-        'language=fin&ssl=true&countryCode=FI&host=areenaylefi' \
-        '&app_id=player_static_prod' \
-        '&app_key=8930d72170e48303cf5f3867780d549b' \
+    return (
+        f'https://player.api.yle.fi/v1/preview/{pid}.json?'
+        'language=fin&ssl=true&countryCode=FI&host=areenaylefi'
+        f'&app_id={APP_ID}&app_key={APP_KEY}'
         '&isPortabilityRegion=true'
+    )
 
 
 def parse_finnish_date(date_string: str) -> Optional[datetime]:

--- a/resources/lib/playlist.py
+++ b/resources/lib/playlist.py
@@ -2,6 +2,7 @@ import html5lib
 import json
 import re
 import requests  # type: ignore
+from .. import APP_ID, APP_KEY
 from . import logger
 from dataclasses import dataclass
 from datetime import datetime
@@ -81,8 +82,8 @@ def download_playlist(
     params = {
         'offset': str(offset),
         'limit': str(page_size),
-        'app_id': 'areena-web-items',
-        'app_key': 'wlTs5D9OjIdeS9krPzRQR4I1PYVzoazN',
+        'app_id': APP_ID,
+        'app_key': APP_KEY,
     }
     playlist_page_url = update_url_query(season_url, params)
     return _parse_series_episode_data(playlist_page_url)


### PR DESCRIPTION
## Summary
- document Programs API endpoints
- centralize app credentials and read from env
- use the credentials for all API requests

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ProxyError: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685d490c82c883318b1724a27df7b8d2