### PR TITLE
Fix pytest import path and skip integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,5 @@
+import os
+import pytest
+
+if not os.environ.get('RUN_INTEGRATION_TESTS'):
+    pytest.skip("Skipping integration tests (RUN_INTEGRATION_TESTS not set)", allow_module_level=True)


### PR DESCRIPTION
## Summary
- ensure `resources` package can be imported when running `pytest`
- skip integration tests unless `RUN_INTEGRATION_TESTS` envvar is set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4f97e0788331bf60d4569364f373