### PR TITLE
Add Media API playout retrieval

### DIFF
--- a/resources/lib/areena.py
+++ b/resources/lib/areena.py
@@ -7,7 +7,17 @@ from datetime import datetime
 from typing import Dict, List, Optional
 from urllib.parse import urlencode
 
+try:
+    import xbmcgui  # type: ignore
+except ImportError:  # pragma: no cover
+    xbmcgui = None
+
+from src.media_api import MediaAPI, Playout
+
 DEFAULT_PAGE_SIZE = 30
+
+_media_api = MediaAPI()
+_playouts: Dict[str, Playout] = {}
 
 
 class AreenaLink:
@@ -285,3 +295,29 @@ def _only_in_areena_live_url(offset: int, page_size: int) -> str:
         'app_key': 'wlTs5D9OjIdeS9krPzRQR4I1PYVzoazN'
     })
     return f'https://areena.api.yle.fi/v1/ui/content/list?{q}'
+
+
+def play(item_id: str):
+    playout = _playouts.get(item_id)
+    if playout is None:
+        playout = _media_api.get_playout(item_id, 'HLS')
+        if playout is None:
+            return None
+        if playout.drm:
+            second = _media_api.get_playout(item_id, 'HLS_DVR')
+            if second is None or second.drm:
+                if xbmcgui:
+                    from .kodi import show_notification
+                    show_notification('DRM-protected – cannot play', icon=xbmcgui.NOTIFICATION_ERROR)
+                return None
+            playout = second
+        _playouts[item_id] = playout
+
+    if xbmcgui:
+        li = xbmcgui.ListItem(path=playout.url, offscreen=True)
+        li.setProperty('inputstreamaddon', 'inputstream.adaptive')
+        li.setMimeType('application/vnd.apple.mpegurl')
+        li.setProperty('inputstream.adaptive.manifest_type', 'hls')
+        return li
+    else:
+        return None

--- a/src/media_api.py
+++ b/src/media_api.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+import os
+from typing import Optional
+
+try:
+    import httpx
+except ImportError:  # pragma: no cover
+    httpx = None
+    import requests
+from pydantic import BaseModel
+
+
+class Playout(BaseModel):
+    url: str
+    drm: bool = False
+    protocol: str
+    language: Optional[str] = None
+
+
+class MediaAPI:
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        app_id: Optional[str] = None,
+        app_key: Optional[str] = None,
+        http: Optional[object] = None,
+    ) -> None:
+        self.base_url = base_url or os.getenv('YLE_MEDIA_BASE_URL', 'https://media.api.yle.fi')
+        self.app_id = app_id or os.getenv('YLE_APP_ID', 'player_static_prod')
+        self.app_key = app_key or os.getenv('YLE_APP_KEY', '8930d72170e48303cf5f3867780d549b')
+        if httpx:
+            self._http_get = (http or httpx.Client(timeout=3.0)).get
+        else:  # pragma: no cover
+            self._http_get = requests.get
+
+    def get_playout(self, item_id: str, protocol: str = 'HLS') -> Optional[Playout]:
+        url = f'{self.base_url}/v2/{item_id}/playouts.json'
+        params = {
+            'app_id': self.app_id,
+            'app_key': self.app_key,
+            'protocol': protocol,
+        }
+        try:
+            r = self._http_get(url, params=params, timeout=3.0)
+            if httpx:
+                r.raise_for_status()
+            elif r.status_code >= 400:  # pragma: no cover
+                raise requests.HTTPError(response=r)
+        except Exception:  # pragma: no cover
+            return None
+        data = r.json().get('data')
+        if isinstance(data, list):
+            info = data[0] if data else None
+        else:
+            info = data
+        if not info or 'url' not in info:
+            return None
+        return Playout(
+            url=info.get('url', ''),
+            drm=bool(info.get('drm')),
+            protocol=info.get('protocol', protocol),
+            language=info.get('language'),
+        )


### PR DESCRIPTION
## Summary
- implement Media API HTTP client with fallback when httpx is missing
- cache playouts and provide new play() helper

## Testing
- `pytest -q` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d52714a4483318514622b3657b9cb